### PR TITLE
feat: add discover movie sync with pagination and filters

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,7 @@
+from typing import Literal
+
 from fastapi import FastAPI
-from app.sync import sync_category
+from app.sync import sync_category, sync_discover_movies
 from app.schemas import FrameReport
 from app.mongo import reports_collection
 
@@ -8,9 +10,14 @@ app = FastAPI()
 
 
 @app.post("/sync/{category}")
-async def sync(category: str):
+async def sync(category: Literal["popular", "top_rated", "upcoming"]):
     result = await sync_category(category)
     return result
+
+
+@app.post("/sync_discover")
+async def sync_discover(pages: int = 1):
+    return await sync_discover_movies(pages)
 
 
 @app.post("/report")

--- a/app/tmdb_client.py
+++ b/app/tmdb_client.py
@@ -67,3 +67,20 @@ async def fetch_best_frames(item_id: int, content_type: str = "movie", limit: in
         print(f"Failed to fetch frames for {content_type} {item_id}: {e}")
         return []
 
+
+async def fetch_discover_movies(page: int = 1) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/discover/movie",
+            params={
+                "api_key": settings.tmdb_api_key,
+                "language": "en-US",
+                "include_adult": False,
+                "sort_by": "popularity.desc",
+                "release_date.gte": "1980-01-01",
+                "release_date.lte": "2025-12-31",
+                "page": page,
+            }
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/app/tools/sync_discover.py
+++ b/app/tools/sync_discover.py
@@ -1,0 +1,7 @@
+import asyncio
+from app.sync import sync_discover_movies
+
+
+if __name__ == "__main__":
+    result = asyncio.run(sync_discover_movies(pages=50))
+    print(result)


### PR DESCRIPTION
- Added /discover/movie sync logic
- Added fetch_discover_movies to tmdb_client.py
- Implemented sync_discover_movies in sync.py
- Filters include date range, adult flag, language, and popularity
- Skips movies without valid frames
