### PR TITLE
feat: add /meta endpoint to provide available genres, countries, and years

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,13 +3,13 @@ from typing import Literal
 from fastapi import FastAPI, Query
 
 from app.endpoints import reports
+from app.meta import get_meta_info
 from app.sync import sync_category, sync_discover_movies
 from app.query import get_random_movie
 
 
 app = FastAPI()
 app.include_router(reports.router)
-
 
 
 @app.post("/sync/{category}")
@@ -40,3 +40,7 @@ async def random_movie(
         is_animated=is_animated,
         _type=_type,
     )
+
+@app.get("/meta")
+async def meta():
+    return await get_meta_info()

--- a/app/meta.py
+++ b/app/meta.py
@@ -1,0 +1,37 @@
+from app.mongo import movies_collection
+
+
+async def get_meta_info():
+    pipeline = [
+        {
+            "$facet": {
+                "genre_ids": [
+                    {"$unwind": "$genre_ids"},
+                    {"$group": {"_id": "$genre_ids"}}
+                ],
+                "country_codes": [
+                    {"$unwind": "$country_codes"},
+                    {"$group": {"_id": "$country_codes"}}
+                ],
+                "years": [
+                    {
+                        "$project": {
+                            "year": {"$toInt": {"$substr": ["$release_date", 0, 4]}}
+                        }
+                    },
+                    {"$group": {"_id": "$year"}}
+                ]
+            }
+        }
+    ]
+
+    result = await movies_collection.aggregate(pipeline).to_list(length=1)
+    if not result:
+        return {"genres": [], "country_codes": [], "years": []}
+
+    data = result[0]
+    return {
+        "genres": sorted(g["_id"] for g in data.get("genre_ids", [])),
+        "country_codes": sorted(c["_id"] for c in data.get("country_codes", [])),
+        "years": sorted(y["_id"] for y in data.get("years", []) if y["_id"]),
+    }


### PR DESCRIPTION
### Add /meta endpoint to provide available genres, countries, and years

---

#### What was added:

* New endpoint `GET /meta` to return filtering metadata for frontend or admin use.
* Aggregates:

  * Unique `genre_ids`
  * Unique `country_codes`
  * Years extracted from `release_date`
* Results are sorted and returned as JSON:

  ```json
  {
    "genres": [28, 35, 53],
    "country_codes": ["US", "FR", "JP"],
    "years": [1985, 1999, 2023]
  }
  ```

**Why:**

This metadata helps dynamically render filters in the UI or admin panels, avoiding hardcoded values and reflecting the actual database contents.

**Next steps (optional):**

* Add caching layer if needed
* Reuse this in internal tools like admin dashboards or statistics UIs