### PR TITLE
feat: generate game rounds from MongoDB movies

### DIFF
--- a/app/endpoints/games.py
+++ b/app/endpoints/games.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+from app.generate_rounds import generate_roundset
+
+
+router = APIRouter()
+
+
+@router.post("/generate_rounds")
+async def generate(set_name: str):
+    result = await generate_roundset(set_name=set_name)
+    return result

--- a/app/generate_rounds.py
+++ b/app/generate_rounds.py
@@ -1,0 +1,79 @@
+import random
+from datetime import datetime
+
+from app.mongo import movies_collection, game_rounds_collection
+
+
+async def generate_roundset(
+    set_name: str,
+    count: int = 100,
+    _type: str = "movie",
+    country_codes: list[str] | None = None,
+    genre_ids: list[int] | None = None,
+    is_animated: bool | None = None,
+    year_from: int | None = None,
+    year_to: int | None = None,
+):
+    query = {
+        "frames.0": {"$exists": True},
+        "_type": _type,
+    }
+
+    if country_codes:
+        query["country_codes"] = {"$in": country_codes}
+    if genre_ids:
+        query["genre_ids"] = {"$in": genre_ids}
+    if is_animated is not None:
+        query["is_animated"] = is_animated
+    if year_from or year_to:
+        query["release_date"] = {}
+        if year_from:
+            query["release_date"]["$gte"] = f"{year_from}-01-01"
+        if year_to:
+            query["release_date"]["$lte"] = f"{year_to}-12-31"
+
+    pipeline = [
+        {"$match": query},
+        {"$sample": {"size": count * 3}}  # oversample to filter later
+    ]
+
+    candidates = await movies_collection.aggregate(pipeline).to_list(length=count * 3)
+    rounds = []
+
+    for movie in candidates:
+        if len(rounds) >= count:
+            break
+
+        title = movie.get("title")
+        if not title:
+            continue
+
+        frame = random.choice(movie.get("frames", []))
+        if not frame:
+            continue
+
+        # Select wrong titles
+        others = [m for m in candidates if m["id"] != movie["id"] and m.get("title")]
+        wrong_titles = random.sample([m["title"] for m in others], k=3)
+
+        rounds.append({
+            "movie_id": movie["id"],
+            "frame_path": frame["path"],
+            "correct_title": title,
+            "wrong_titles": wrong_titles,
+            "title_ru": movie.get("title_ru"),
+            "release_year": int(movie.get("release_date", "0000")[:4]),
+            "_type": movie["_type"],
+            "_category": movie.get("_category"),
+            "genre_ids": movie.get("genre_ids", []),
+            "country_codes": movie.get("country_codes", []),
+            "is_animated": movie.get("is_animated", False),
+            "difficulty": "medium",
+            "set_name": set_name,
+            "created_at": datetime.utcnow()
+        })
+
+    if rounds:
+        await game_rounds_collection.insert_many(rounds)
+
+    return {"inserted": len(rounds)}

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from fastapi import FastAPI, Query
 
-from app.endpoints import reports
+from app.endpoints import reports, games
 from app.meta import get_meta_info
 from app.scheduler import start_scheduler
 from app.sync import sync_category, sync_discover_movies
@@ -11,6 +11,7 @@ from app.query import get_random_movie
 
 app = FastAPI()
 app.include_router(reports.router)
+app.include_router(games.router)
 
 
 @app.on_event("startup")

--- a/app/mongo.py
+++ b/app/mongo.py
@@ -5,5 +5,6 @@ from app.config import settings
 client = AsyncIOMotorClient(settings.mongo_url)
 db = client[settings.mongo_db]
 movies_collection = db["movies"]
-frame_reports_collection = db["frame_reports_collection"]
+frame_reports_collection = db["frame_reports"]
 sync_errors_collection = db.sync_errors
+game_rounds_collection = db["game_rounds"]

--- a/app/tools/generate_roundset.py
+++ b/app/tools/generate_roundset.py
@@ -1,0 +1,21 @@
+import asyncio
+from app.generate_rounds import generate_roundset  # путь к твоей функции
+from app.mongo import connect_to_mongo, close_mongo
+
+async def main():
+    await connect_to_mongo()
+    result = await generate_roundset(
+        set_name="roundset_01",
+        count=100,
+        _type="movie",
+        country_codes=["US"],
+        genre_ids=[18, 53],
+        is_animated=False,
+        year_from=1980,
+        year_to=2023
+    )
+    print(result)
+    await close_mongo()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
### 📝 **Pull Request Description:**

Added the `generate_roundset()` function to create game rounds based on movies stored in MongoDB. Each round includes one frame, the correct movie title, and three distractor (incorrect) titles. The generated rounds are saved to the `game_rounds` collection.

**Each round includes the following fields:**

* `movie_id`, `frame_path`
* `correct_title`, `wrong_titles`
* `title_ru`, `release_year`, `genre_ids`, `country_codes`
* `set_name`, `difficulty`, `created_at`

**Filter options:**

* `genre_ids`
* `country_codes`
* `release_date` (via `year_from`, `year_to`)
* `_type` (`movie` or `tv`)
* `is_animated`

This tool is intended for generating roundsets manually and reviewing them before they are used in the game logic.
